### PR TITLE
fix students stats graph

### DIFF
--- a/platform_orchestrator/src/main/resources/static/js/statistics.js
+++ b/platform_orchestrator/src/main/resources/static/js/statistics.js
@@ -20,7 +20,7 @@ const dataOfSteps = {
 
 const dataOfUsers = {
     datasets: [{
-        label: 'Ученики',
+        label: 'Количество дней',
         backgroundColor: 'rgb(255,0,255)',
         borderColor: 'rgb(100, 99, 132)',
         data: statisticsData.studentsCodeTry,


### PR DESCRIPTION
изменила лейбл для графика количества дней обучения
было
![Screenshot 2022-06-28 at 04 15 43](https://user-images.githubusercontent.com/53154670/176065982-557fc734-25a4-40f0-80d3-31ef6b2f7bb0.jpg)
стало
![Screenshot 2022-06-28 at 04 15 15](https://user-images.githubusercontent.com/53154670/176065926-99ff6527-af07-4c03-964e-83dd9605fb1e.jpg)