### PR TITLE
Dependency versions have been updated

### DIFF
--- a/platform_code_executor/src/main/java/com/override/controller/ExecuteCodeController.java
+++ b/platform_code_executor/src/main/java/com/override/controller/ExecuteCodeController.java
@@ -4,7 +4,7 @@ import com.override.service.ExecuteCodeService;
 import com.override.service.StepikService;
 import dto.CodeTryDTO;
 import dto.TestResultDTO;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,7 +20,7 @@ public class ExecuteCodeController {
     private StepikService stepikService;
 
     @PostMapping("/execute")
-    @ApiOperation("Возвращает результат проверки кода задачи")
+    @Operation(summary = "Возвращает результат проверки кода задачи")
     public TestResultDTO execute(@RequestBody CodeTryDTO codeTryDTO) {
         if (codeTryDTO.getAttempt() != null) {
             return stepikService.runStepikCode(codeTryDTO);

--- a/platform_code_executor/src/main/java/com/override/feign/StepikCodeExecutorFeign.java
+++ b/platform_code_executor/src/main/java/com/override/feign/StepikCodeExecutorFeign.java
@@ -1,8 +1,8 @@
 package com.override.feign;
 
 import dto.StepikTokenDTO;
-import io.swagger.annotations.ApiOperation;
 
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.*;
 
@@ -10,14 +10,14 @@ import org.springframework.web.bind.annotation.*;
 public interface StepikCodeExecutorFeign {
 
     @PostMapping(value = "/api/submissions", consumes = "application/json", produces = "application/json")
-    @ApiOperation(value = "Отправляет код на проверку StepikAPI")
+    @Operation(summary = "Отправляет код на проверку StepikAPI")
     void execute(@RequestHeader(value = "Authorization", required = true) String token, @RequestBody String json);
 
     @GetMapping(value = "/api/submissions?limit=1&order=desc", consumes = "application/json", produces = "application/json")
-    @ApiOperation(value = "Зарашивает результаты проверки на конкретную задачу - numberOfStep")
+    @Operation(summary = "Запрашивает результаты проверки на конкретную задачу - numberOfStep")
     String getResult(@RequestParam(value = "step") String numberOfStep, @RequestHeader(value = "Authorization", required = true) String token);
 
     @PostMapping(value = "/oauth2/token/?grant_type=client_credentials", consumes = "application/json", produces = "application/json")
-    @ApiOperation(value = "Запрашивает токен у StepikAPI по логину и паролю клиента")
+    @Operation(summary = "Запрашивает токен у StepikAPI по логину и паролю клиента")
     StepikTokenDTO getToken(@RequestHeader(value = "Authorization", required = true) String auth);
 }

--- a/platform_dto/pom.xml
+++ b/platform_dto/pom.xml
@@ -51,9 +51,9 @@
         </dependency>
 
         <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-boot-starter</artifactId>
-            <version>3.0.0</version>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
+            <version>1.6.14</version>
         </dependency>
 
     </dependencies>

--- a/platform_dto/src/main/java/dto/BalanceResponseFromNotificationControllerDTO.java
+++ b/platform_dto/src/main/java/dto/BalanceResponseFromNotificationControllerDTO.java
@@ -1,15 +1,14 @@
 package dto;
 
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @AllArgsConstructor
 @Data
 public class BalanceResponseFromNotificationControllerDTO {
-
-    @ApiModelProperty(value = "Баланс на sms.ru в рублях (есть только у админа)")
+    @Schema(description = "Баланс на sms.ru в рублях (есть только у админа)")
     private double balance;
-    @ApiModelProperty(value = "Ссылка для пополнения баланса (https://sms.ru/pay.php)")
+    @Schema(description = "Ссылка для пополнения баланса (https://sms.ru/pay.php)")
     private String urlToReplenishBalance;
 }

--- a/platform_dto/src/main/java/dto/CodeTryStatDTO.java
+++ b/platform_dto/src/main/java/dto/CodeTryStatDTO.java
@@ -1,7 +1,6 @@
 package dto;
 
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -10,18 +9,18 @@ import java.util.Map;
 
 @Data
 @Builder
-@ApiModel
+@Schema
 public class CodeTryStatDTO {
-    @ApiModelProperty(value = "Мапа Map<String, Long>, где ключ(String) - номер той самой сложной задачи " +
+    @Schema(description = "Мапа Map<String, Long>, где ключ(String) - номер той самой сложной задачи " +
             "(пример: 4.2.1, где 4 - глава, 2 - шаг, 1 - урок), а значение(Long) - количество неудачных решений данной задачи")
     private Map<String, Long> hardTasks;
-    @ApiModelProperty(value = "Мапа Map<String, BigInteger>, где ключ(String) - название статуса по выполнению " +
+    @Schema(description = "Мапа Map<String, BigInteger>, где ключ(String) - название статуса по выполнению " +
             "задачи (пример: 'COMPILE_ERROR' или 'OK'), а значение(BigInteger) - количество данных статусов в таблице")
     private Map<String, BigInteger> codeTryStatus;
-    @ApiModelProperty(value = "Мапа Map<String, BigInteger>, где ключ(String) - логин студента (пример: 'Raymon'), " +
+    @Schema(description = "Мапа Map<String, BigInteger>, где ключ(String) - логин студента (пример: 'Raymon'), " +
             "а значение(BigInteger) - общее количество попыток решений задач для данного студента")
     private Map<String, BigInteger> studentsCodeTry;
-    @ApiModelProperty(value = "Мапа Map<String, Double>, где ключ(String) - номер главы и шага (пример: 4.2, где 4 - глава, 2 - шаг), " +
+    @Schema(description = "Мапа Map<String, Double>, где ключ(String) - номер главы и шага (пример: 4.2, где 4 - глава, 2 - шаг), " +
             "а значение(Double) - среднее количество попыток выполнения данного шага данной главы в одном уроке, если проще, то среднее количество попыток выполнения данного шага")
     private Map<String, Double> hardStepRatio;
 }

--- a/platform_dto/src/main/java/dto/GeneralIncomeDTO.java
+++ b/platform_dto/src/main/java/dto/GeneralIncomeDTO.java
@@ -1,6 +1,6 @@
 package dto;
 
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -10,9 +10,9 @@ import java.util.List;
 @Data
 @Builder
 public class GeneralIncomeDTO {
-    @ApiModelProperty(value = "Лист с датами по месяцам. Здесь каждая дата - первое число каждого месяца. " +
+    @Schema(description = "Лист с датами по месяцам. Здесь каждая дата - первое число каждого месяца. " +
             "Самая первая дата - это первое число того месяца, в котором был первый платеж от студента")
     private List<LocalDate> dataMonth;
-    @ApiModelProperty(value = "Лист с доходами от студентов за каждый месяц")
+    @Schema(description = "Лист с доходами от студентов за каждый месяц")
     private List<Double> income;
 }

--- a/platform_dto/src/main/java/dto/IncomeFromUsersDTO.java
+++ b/platform_dto/src/main/java/dto/IncomeFromUsersDTO.java
@@ -1,6 +1,6 @@
 package dto;
 
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -9,8 +9,8 @@ import java.util.List;
 @Data
 @Builder
 public class IncomeFromUsersDTO {
-    @ApiModelProperty(value = "Лист с именами всех студентов (логинами), имена не могу повторятся")
+    @Schema(description = "Лист с именами всех студентов (логинами), имена не могу повторятся")
     private List<String> studentName;
-    @ApiModelProperty(value = "Лист суммарных доходов от каждого студента")
+    @Schema(description = "Лист суммарных доходов от каждого студента")
     private List<Long> income;
 }

--- a/platform_dto/src/main/java/dto/InterviewDataDTO.java
+++ b/platform_dto/src/main/java/dto/InterviewDataDTO.java
@@ -1,6 +1,6 @@
 package dto;
 
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -12,36 +12,36 @@ import java.time.LocalTime;
 public class InterviewDataDTO {
     private Long id;
 
-    @ApiModelProperty(value = "Логин пользователя")
+    @Schema(description = "Логин пользователя")
     private String userLogin;
 
-    @ApiModelProperty(value = "Название компании")
+    @Schema(description = "Название компании")
     private String company;
 
-    @ApiModelProperty(value = "Описание вакансии")
+    @Schema(description = "Описание вакансии")
     private String description;
 
-    @ApiModelProperty(value = "Контакты для связи")
+    @Schema(description = "Контакты для связи")
     private String contacts;
 
-    @ApiModelProperty(value = "Дата собеседования")
+    @Schema(description = "Дата собеседования")
     private LocalDate date;
 
-    @ApiModelProperty(value = "Время собеседования")
+    @Schema(description = "Время собеседования")
     private LocalTime time;
 
-    @ApiModelProperty(value = "Комментарий после собеседования")
+    @Schema(description = "Комментарий после собеседования")
     private String comment;
 
-    @ApiModelProperty(value = "Стек")
+    @Schema(description = "Стек")
     private String stack;
 
-    @ApiModelProperty(value = "Предлагаемая зарплата")
+    @Schema(description = "Предлагаемая зарплата")
     private int salary;
 
-    @ApiModelProperty(value = "Ссылка на встречу")
+    @Schema(description = "Ссылка на встречу")
     private String meetingLink;
 
-    @ApiModelProperty(value = "Уточнение, возможна ли удаленка")
+    @Schema(description = "Уточнение, возможна ли удаленка")
     private String distanceWork;
 }

--- a/platform_dto/src/main/java/dto/JoinRequestStatusDTO.java
+++ b/platform_dto/src/main/java/dto/JoinRequestStatusDTO.java
@@ -1,6 +1,6 @@
 package dto;
 
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class JoinRequestStatusDTO {
-    @ApiModelProperty(value = "Будет одно из трех сообщений", example = "\"В этом чате уже есть запрос на " +
+    @Schema(description = "Будет одно из трех сообщений", example = "\"В этом чате уже есть запрос на " +
             "регистрацию\", \"Вы уже зарегистрированы\", \"Ваш запрос на регистрацию в платформе создан, " +
             "ожидайте подтверждения\"")
     private String message;

--- a/platform_dto/src/main/java/dto/PaymentDTO.java
+++ b/platform_dto/src/main/java/dto/PaymentDTO.java
@@ -1,7 +1,7 @@
 package dto;
 
 import enums.PaymentStatus;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @Data
 @Builder
 public class PaymentDTO {
-    @ApiModelProperty(value = "Номер рассчетного счета, куда делается платеж (номер карты получателя платежа)")
+    @Schema(description = "Номер рассчетного счета, куда делается платеж (номер карты получателя платежа)")
     private Long accountNumber;
     private String comment;
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)

--- a/platform_dto/src/main/java/dto/PersonalDataDTO.java
+++ b/platform_dto/src/main/java/dto/PersonalDataDTO.java
@@ -1,6 +1,6 @@
 package dto;
 
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -10,68 +10,68 @@ import java.time.LocalDate;
 @Builder
 public class PersonalDataDTO {
 
-    @ApiModelProperty(
-            value = "Id персональных данных",
+    @Schema(
+            description = "Id персональных данных",
             example = "222L")
     private	Long id;
 
-    @ApiModelProperty(
-            value = "Номер акта",
+    @Schema(
+            description = "Номер акта",
             example = "222L")
     private Long actNumber;
 
-    @ApiModelProperty(
-            value = "Номер контракта",
+    @Schema(
+            description = "Номер контракта",
             example = "22/22/2222")
     private String contractNumber;
 
-    @ApiModelProperty(
-            value = "Дата подписания контракта",
+    @Schema(
+            description = "Дата подписания контракта",
             example = "22.22.2222")
     private LocalDate contractDate;
 
-    @ApiModelProperty(
-            value = "Полное имя (ФИО)",
+    @Schema(
+            description = "Полное имя (ФИО)",
             example = "Ernesto Denesik DDS")
     private String fullName;
 
-    @ApiModelProperty(
-            value = "Серия паспорта",
+    @Schema(
+            description = "Серия паспорта",
             example = "1673")
     private Long passportSeries;
 
-    @ApiModelProperty(
-            value = "Номер паспорта",
+    @Schema(
+            description = "Номер паспорта",
             example = "568174")
     private Long passportNumber;
 
-    @ApiModelProperty(
-            value = "Кем паспорт выдан",
+    @Schema(
+            description = "Кем паспорт выдан",
             example = "3261 Annette Coves, Port Sumiko, IN 66449")
     private String passportIssued;
 
-    @ApiModelProperty(
-            value = "Годен паспорт до",
+    @Schema(
+            description = "Годен паспорт до",
             example = "22.22.2222")
     private LocalDate issueDate;
 
-    @ApiModelProperty(
-            value = "Дата рождения",
+    @Schema(
+            description = "Дата рождения",
             example = "22.22.2222")
     private LocalDate birthDate;
 
-    @ApiModelProperty(
-            value = "Регистрация",
+    @Schema(
+            description = "Регистрация",
             example = "51981 Schoen Mews, North Stasiabury, DE 83709-7555")
     private String registration;
 
-    @ApiModelProperty(
-            value = "Почта",
+    @Schema(
+            description = "Почта",
             example = "chauncey54@gmail.com")
     private String email;
 
-    @ApiModelProperty(
-            value = "Номер телефона ",
+    @Schema(
+            description = "Номер телефона ",
             example = "81116327532")
     private Long phoneNumber;
 }

--- a/platform_dto/src/main/java/dto/SalaryDTO.java
+++ b/platform_dto/src/main/java/dto/SalaryDTO.java
@@ -1,6 +1,6 @@
 package dto;
 
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -12,8 +12,8 @@ public class SalaryDTO {
     /**
      * labels which contains dates for salary graphic
      */
-    @ApiModelProperty(value = "Лист с датами зарплат, даты для каждого юзера начинаются с принятия оффера по сегодняшний день")
+    @Schema(description = "Лист с датами зарплат, даты для каждого юзера начинаются с принятия оффера по сегодняшний день")
     private List<String> labels;
-    @ApiModelProperty(value = "SalaryStatDTO, в этой ДТОшке логин юзера и список зарплат данного юзера для каждой даты из листа 'labels'")
+    @Schema(description = "SalaryStatDTO, в этой ДТОшке логин юзера и список зарплат данного юзера для каждой даты из листа 'labels'")
     private List<SalaryStatDTO> salaryStats;
 }

--- a/platform_dto/src/main/java/dto/SalaryStatDTO.java
+++ b/platform_dto/src/main/java/dto/SalaryStatDTO.java
@@ -1,6 +1,6 @@
 package dto;
 
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -12,12 +12,12 @@ public class SalaryStatDTO {
     /**
      * this is label for salary graph which contains logins
      */
-    @ApiModelProperty(value = "Логин юзера, которй уже принял оффер и работает")
+    @Schema(description = "Логин юзера, которй уже принял оффер и работает")
     private String label;
     /**
      * this is dataset for salary graph which contains salaries of users
      */
-    @ApiModelProperty(value = "Лист со списком зарплат данного юзера")
+    @Schema(description = "Лист со списком зарплат данного юзера")
     private List<Integer> data;
     private Integer borderWidth;
 }

--- a/platform_dto/src/main/java/dto/VkActorDTO.java
+++ b/platform_dto/src/main/java/dto/VkActorDTO.java
@@ -1,6 +1,6 @@
 package dto;
 
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -8,18 +8,15 @@ import lombok.Data;
 @Builder
 public class VkActorDTO {
 
-    @ApiModelProperty(
-            value = "Токен доступа к VK API",
+    @Schema(description = "Токен доступа к VK API",
             example = "vk1.a._4sor6Cg_2YkL3-g5YDaaAHKYSp8NjNDiTCen5mC5XstRpXSn4")
     private String accessToken;
 
-    @ApiModelProperty(
-            value = "Время жизни токена 'access token'",
+    @Schema(description = "Время жизни токена 'access token'",
             example = "86400")
     private Long expiresIn;
 
-    @ApiModelProperty(
-            value = "ID VK страницы, с которой делается запрос",
+    @Schema(description = "ID VK страницы, с которой делается запрос",
             example = "125053L")
     private Long userId;
 }

--- a/platform_dto/src/main/java/dto/YooMoneyConfirmationRequestDTO.java
+++ b/platform_dto/src/main/java/dto/YooMoneyConfirmationRequestDTO.java
@@ -1,7 +1,7 @@
 package dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -13,13 +13,13 @@ public class YooMoneyConfirmationRequestDTO {
 
     private Confirmation confirmation;
 
-    @ApiModelProperty(value = "Автоматический прием поступившего платежа.")
+    @Schema(description = "Автоматический прием поступившего платежа.")
     private Boolean capture;
 
-    @ApiModelProperty(value = "Описание транзакции (не более 128 символов)")
+    @Schema(description = "Описание транзакции (не более 128 символов)")
     private String description;
 
-    @ApiModelProperty(value = "Идентификатор покупателя в нашей системе (Login)")
+    @Schema(description = "Идентификатор покупателя в нашей системе (Login)")
     @JsonProperty("merchant_customer_id")
     private String merchantCustomerId;
 
@@ -27,10 +27,10 @@ public class YooMoneyConfirmationRequestDTO {
     @Data
     public static class Amount {
 
-        @ApiModelProperty(value = "Сумма платежа.")
+        @Schema(description = "Сумма платежа.")
         private double value;
 
-        @ApiModelProperty(value = "Сумма платежа.")
+        @Schema(description = "Сумма платежа.")
         private String currency;
     }
 
@@ -38,7 +38,7 @@ public class YooMoneyConfirmationRequestDTO {
     @Data
     public static class Confirmation {
 
-        @ApiModelProperty(value = "Код сценария подтверждения.", example = "embedded")
+        @Schema(description = "Код сценария подтверждения.", example = "embedded")
         private String type;
     }
 }

--- a/platform_dto/src/main/java/dto/YooMoneyConfirmationResponseDTO.java
+++ b/platform_dto/src/main/java/dto/YooMoneyConfirmationResponseDTO.java
@@ -2,7 +2,7 @@ package dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import enums.PaymentStatus;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -10,59 +10,59 @@ import lombok.Data;
 @Builder
 public class YooMoneyConfirmationResponseDTO {
 
-    @ApiModelProperty(value = "Идентификатор платежа в ЮKassa.")
+    @Schema(description = "Идентификатор платежа в ЮKassa.")
     private String id;
 
-    @ApiModelProperty(value = "Статус платежа. Возможные значения: pending, waiting_for_capture, succeeded и canceled.")
+    @Schema(description = "Статус платежа. Возможные значения: pending, waiting_for_capture, succeeded и canceled.")
     private PaymentStatus status;
 
     private Amount amount;
 
-    @ApiModelProperty(value = "Описание транзакции (не более 128 символов)")
+    @Schema(description = "Описание транзакции (не более 128 символов)")
     private String description;
 
     private Recipient recipient;
 
-    @ApiModelProperty(value = "Время создания заказа. Указывается по UTC и передается в формате ISO 8601.")
+    @Schema(description = "Время создания заказа. Указывается по UTC и передается в формате ISO 8601.")
     @JsonProperty("created_at")
     private String createdAt;
 
     private Confirmation confirmation;
 
-    @ApiModelProperty(value = "Признак тестовой операции.")
+    @Schema(description = "Признак тестовой операции.")
     private Boolean test;
 
-    @ApiModelProperty(value = "Признак успешной оплаты.")
+    @Schema(description = "Признак успешной оплаты.")
     private Boolean paid;
 
-    @ApiModelProperty("Признак возможности провести возврат по API.")
+    @Schema(description = "Признак возможности провести возврат по API.")
     private Boolean refundable;
 
-    @ApiModelProperty(value = "Любые дополнительные данные, которые нужны вам для работы.")
+    @Schema(description = "Любые дополнительные данные, которые нужны вам для работы.")
     private Object metadata;
 
-    @ApiModelProperty(value = "Идентификатор покупателя в нашей системе (Login)")
+    @Schema(description = "Идентификатор покупателя в нашей системе (Login)")
     @JsonProperty("merchant_customer_id")
     private String merchantCustomerId;
 
     @Data
     public static class Amount {
 
-        @ApiModelProperty(value = "Сумма платежа.")
+        @Schema(description = "Сумма платежа.")
         private double value;
 
-        @ApiModelProperty(value = "Сумма платежа.")
+        @Schema(description = "Сумма платежа.")
         private String currency;
     }
 
     @Data
     public static class Recipient {
 
-        @ApiModelProperty(value = "Идентификатор магазина в ЮKassa.")
+        @Schema(description = "Идентификатор магазина в ЮKassa.")
         @JsonProperty("account_id")
         private Integer accountId;
 
-        @ApiModelProperty(value = "Идентификатор субаккаунта." +
+        @Schema(description = "Идентификатор субаккаунта." +
                 " Используется для разделения потоков платежей в рамках одного аккаунта.")
         @JsonProperty("gateway_id")
         private Integer gatewayId;
@@ -71,10 +71,10 @@ public class YooMoneyConfirmationResponseDTO {
     @Data
     public static class Confirmation {
 
-        @ApiModelProperty(value = "Код сценария подтверждения.", example = "embedded")
+        @Schema(description = "Код сценария подтверждения.", example = "embedded")
         private String type;
 
-        @ApiModelProperty(value = "Токен для инициализации платежного виджета ЮKassa ")
+        @Schema(description = "Токен для инициализации платежного виджета ЮKassa ")
         @JsonProperty("confirmation_token")
         private String confirmationToken;
     }

--- a/platform_dto/src/main/java/dto/YooMoneyRequestInfoDTO.java
+++ b/platform_dto/src/main/java/dto/YooMoneyRequestInfoDTO.java
@@ -1,17 +1,17 @@
 package dto;
 
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 @Data
 public class YooMoneyRequestInfoDTO {
 
-    @ApiModelProperty(value = "Сумма платежа")
+    @Schema(description = "Сумма платежа")
     private Double amount;
 
-    @ApiModelProperty(value = "Комментарий к платежу")
+    @Schema(description = "Комментарий к платежу")
     private String comment;
 
-    @ApiModelProperty(value = "Login плательщика")
+    @Schema(description = "Login плательщика")
     private String login;
 }

--- a/platform_notification/src/main/java/com/override/feign/TelegramFeign.java
+++ b/platform_notification/src/main/java/com/override/feign/TelegramFeign.java
@@ -4,11 +4,9 @@ import dto.MessageDTO;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 
 @FeignClient(name = "bot")
-@RequestMapping("/messages")
 public interface TelegramFeign {
-    @PostMapping
+    @PostMapping("/messages")
     void sendMessage(@RequestBody MessageDTO message);
 }

--- a/platform_notification/src/main/resources/application.yml
+++ b/platform_notification/src/main/resources/application.yml
@@ -44,6 +44,8 @@ spring:
     port: 465
     username: ${MAIL_USER_NAME}
     password: ${MAIL_PASSWORD}
+  main:
+    allow-circular-references: true
 token:
   X-MS-AUTH: ${MICROSERVICES_SECRET_TOKEN:0LDRhdGD0LXRgtGMINC90LUg0LLRgdGC0LDRgtGMXl4=}
 

--- a/platform_orchestrator/pom.xml
+++ b/platform_orchestrator/pom.xml
@@ -170,9 +170,9 @@
         </dependency>
 
         <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-boot-starter</artifactId>
-            <version>3.0.0</version>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
+            <version>1.6.14</version>
         </dependency>
 
         <dependency>

--- a/platform_orchestrator/src/main/java/com/override/PlatformOrchestratorApplication.java
+++ b/platform_orchestrator/src/main/java/com/override/PlatformOrchestratorApplication.java
@@ -1,6 +1,9 @@
 package com.override;
 
 import com.override.properties.NavbarProperties;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -9,17 +12,11 @@ import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @EnableFeignClients
 @SpringBootApplication
 @EnableDiscoveryClient
 @EnableScheduling
-@EnableSwagger2
 @EnableCaching
 @EnableConfigurationProperties(NavbarProperties.class)
 //@ComponentScan( basePackageClasses = FeignConfiguration.class)
@@ -29,11 +26,11 @@ public class PlatformOrchestratorApplication {
     }
 
     @Bean
-    public Docket api() {
-        return new Docket(DocumentationType.SWAGGER_2)
-                .select()
-                .apis(RequestHandlerSelectors.any())
-                .paths(PathSelectors.any())
-                .build();
+    public OpenAPI springShopOpenAPI() {
+        return new OpenAPI()
+                .info(new Info().title("Platform API")
+                        .description("Platform for Java students")
+                        .version("v0.0.1")
+                        .license(new License().name("Apache 2.0").url("http://springdoc.org")));
     }
 }

--- a/platform_orchestrator/src/main/java/com/override/controller/DocumentController.java
+++ b/platform_orchestrator/src/main/java/com/override/controller/DocumentController.java
@@ -5,7 +5,7 @@ import com.override.model.Document;
 import com.override.service.CustomStudentDetailService;
 import com.override.service.DocumentService;
 import dto.DocumentDTO;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import org.apache.commons.fileupload.FileUploadException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
@@ -67,7 +67,7 @@ public class DocumentController {
 
     @GetMapping("/documentList/{id}")
     @ResponseBody
-    @ApiOperation(value = "Возвращает все \"документы\" студента по его id")
+    @Operation(summary = "Возвращает все \"документы\" студента по его id")
     public List<DocumentDTO> getStudentDocuments(@PathVariable Long id) {
         return documentService.findAllByUserId(id);
     }

--- a/platform_orchestrator/src/main/java/com/override/controller/rest/ActGenerationRestController.java
+++ b/platform_orchestrator/src/main/java/com/override/controller/rest/ActGenerationRestController.java
@@ -3,7 +3,7 @@ package com.override.controller.rest;
 import com.override.service.ActGenerationService;
 import com.override.service.CustomStudentDetailService;
 import com.override.service.PlatformUserService;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
@@ -26,13 +26,13 @@ public class ActGenerationRestController {
 
     @Secured("ROLE_ADMIN")
     @GetMapping("{studentLogin}")
-    @ApiOperation(value = "Создает акт о выполненной работе формата .PDF для админа")
+    @Operation(summary = "Создает акт о выполненной работе формата .PDF для админа")
     public void generateAct(@PathVariable String studentLogin) {
         actGenerationService.createPDF(platformUserService.findPlatformUserByLogin(studentLogin).getPersonalData());
     }
 
     @GetMapping
-    @ApiOperation(value = "Создает акт о выполненной работе формата .PDF для текущего юзера")
+    @Operation(summary = "Создает акт о выполненной работе формата .PDF для текущего юзера")
     public ResponseEntity<Resource> generateCurrentUserAct(@AuthenticationPrincipal CustomStudentDetailService.CustomStudentDetails user) {
         return ResponseEntity.ok()
                 .contentType(MediaType.parseMediaType("application/pdf"))

--- a/platform_orchestrator/src/main/java/com/override/controller/rest/AuthRestController.java
+++ b/platform_orchestrator/src/main/java/com/override/controller/rest/AuthRestController.java
@@ -2,7 +2,7 @@ package com.override.controller.rest;
 
 import com.override.model.AuthRequest;
 import com.override.service.AuthService;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,7 +15,7 @@ public class AuthRestController {
     private final AuthService authService;
 
     @PostMapping("/login")
-    @ApiOperation(value = "Если логин и пароль верны, то возвращается токен пользователя.")
+    @Operation(summary = "Если логин и пароль верны, то возвращается токен пользователя.")
     public String auth(@RequestBody AuthRequest request) {
         return authService.login(request.getLogin(), request.getPassword());
     }

--- a/platform_orchestrator/src/main/java/com/override/controller/rest/BugReportRestController.java
+++ b/platform_orchestrator/src/main/java/com/override/controller/rest/BugReportRestController.java
@@ -5,7 +5,7 @@ import com.override.model.Bug;
 import com.override.service.BugReportService;
 import com.override.service.CustomStudentDetailService;
 import dto.BugReportsDTO;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import org.apache.commons.fileupload.FileUploadException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
@@ -28,7 +28,7 @@ public class BugReportRestController {
 
     @PostMapping
     @MaxFileSize("${documentSizeLimit.forBugReports}")
-    @ApiOperation(value = "Если формат файла верный, то сохраняет баг в таблицу с \"баг репортами\" в БД. " +
+    @Operation(summary = "Если формат файла верный, то сохраняет баг в таблицу с \"баг репортами\" в БД. " +
             "Плюс всем админам на почту приходит сообщение о том, что пользователь прислал баг")
     public void uploadBug(@AuthenticationPrincipal CustomStudentDetailService.CustomStudentDetails user,
                           @RequestPart("file") MultipartFile multipartFile, @RequestPart("bugDescription") String text) throws FileUploadException {
@@ -36,13 +36,13 @@ public class BugReportRestController {
     }
 
     @GetMapping
-    @ApiOperation(value = "Возвращает все \"баг репорты\" из БД")
+    @Operation(summary = "Возвращает все \"баг репорты\" из БД")
     public List<BugReportsDTO> getAllBugs() {
         return bugReportService.getAll();
     }
 
     @GetMapping("/{id}")
-    @ApiOperation(value = "Возвращает файл, прикрепленный к \"баг репорту\"")
+    @Operation(summary = "Возвращает файл, прикрепленный к \"баг репорту\"")
     public ResponseEntity<Resource> downloadFile(@PathVariable Long id) {
         Bug bug = bugReportService.downloadFile(id);
         return ResponseEntity.ok()

--- a/platform_orchestrator/src/main/java/com/override/controller/rest/CodeTryRestController.java
+++ b/platform_orchestrator/src/main/java/com/override/controller/rest/CodeTryRestController.java
@@ -7,9 +7,9 @@ import dto.CodeTryDTO;
 import dto.TaskIdentifierDTO;
 import dto.TestResultDTO;
 import enums.CodeExecutionStatus;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -34,10 +34,10 @@ public class CodeTryRestController {
     private CodeTryService codeTryService;
 
     @PostMapping
-    @ApiOperation(value = "Если в коде нет синтаксических ошибок и он проходит по длине, то сохраняет \"код трай\" в БД")
+    @Operation(summary = "Если в коде нет синтаксических ошибок и он проходит по длине, то сохраняет \"код трай\" в БД")
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Все тесты пройдены"),
-            @ApiResponse(code = 400, message = "Введенный код некорректен (не прошел по длине), либо сообщение будет по типу - не пройден такой-то тест, и такая-то ошибка"),
+            @ApiResponse(responseCode = "200", description = "Все тесты пройдены"),
+            @ApiResponse(responseCode = "400", description = "Введенный код некорректен (не прошел по длине), либо сообщение будет по типу - не пройден такой-то тест, и такая-то ошибка")
     })
     public ResponseEntity<String> getCodeTryResult(@RequestBody @Valid CodeTryDTO codeTryDTO, BindingResult result,
                                                    @AuthenticationPrincipal CustomStudentDetails user) {
@@ -57,7 +57,7 @@ public class CodeTryRestController {
     }
 
     @GetMapping
-    @ApiOperation(value = "Возвращает все \"код трай\" для текущего юзера по главе, шагу и уроку")
+    @Operation(summary = "Возвращает все \"код трай\" для текущего юзера по главе, шагу и уроку")
     public List<CodeTry> studentCodesLesson(@AuthenticationPrincipal CustomStudentDetails user,
                                             @RequestParam int chapter, @RequestParam int step, @RequestParam int lesson) {
         TaskIdentifierDTO taskIdentifierDTO = TaskIdentifierDTO.builder()
@@ -69,7 +69,7 @@ public class CodeTryRestController {
     }
 
     @GetMapping("/{id}")
-    @ApiOperation(value = "Возвращает все \"код трай\" студента по его id")
+    @Operation(summary = "Возвращает все \"код трай\" студента по его id")
     public List<CodeTry> getStudentTries(@PathVariable Long id) {
         return codeTryService.findAllByUserId(id);
     }

--- a/platform_orchestrator/src/main/java/com/override/controller/rest/DefaultQuestionRestController.java
+++ b/platform_orchestrator/src/main/java/com/override/controller/rest/DefaultQuestionRestController.java
@@ -3,7 +3,7 @@ package com.override.controller.rest;
 import com.override.model.DefaultQuestion;
 import com.override.service.DefaultQuestionService;
 import dto.DefaultQuestionDTO;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,32 +15,33 @@ public class DefaultQuestionRestController {
     @Autowired
     private DefaultQuestionService defaultQuestionService;
 
-    @ApiOperation(value = "Возвращает все дефолтные вопросы из БД")
+    @Operation(summary = "Возвращает все дефолтные вопросы из БД")
     @GetMapping
     public List<DefaultQuestion> findDefaultQuestions() {
         return defaultQuestionService.findAll();
     }
 
-    @ApiOperation(value = "Возвращает дефолтные вопросы по главе и секции")
+//    @ApiOperation(value = "Возвращает дефолтные вопросы по главе и секции")
+    @Operation(summary = "Возвращает дефолтные вопросы по главе и секции")
     @PostMapping
     public List<DefaultQuestion> findDefaultQuestionsByChapterAndSection(@RequestBody DefaultQuestionDTO defaultQuestionDTO) {
         return defaultQuestionService.findAllByChapterAndSection(defaultQuestionDTO.getChapter(), defaultQuestionDTO.getSection());
     }
 
     @PatchMapping
-    @ApiOperation(value = "Сохраняет дефолтный вопрос в БД")
+    @Operation(summary = "Сохраняет дефолтный вопрос в БД")
     public void patchDefaultQuestion(@RequestBody DefaultQuestion defaultQuestion) {
         defaultQuestionService.save(defaultQuestion);
     }
 
     @PutMapping
-    @ApiOperation(value = "Обновляет дефолтный вопрос в БД")
+    @Operation(summary = "Обновляет дефолтный вопрос в БД")
     public void editDefaultQuestion(@RequestBody DefaultQuestion defaultQuestion) {
         defaultQuestionService.update(defaultQuestion);
     }
 
     @DeleteMapping
-    @ApiOperation(value = "Удаляет дефолтный вопрос по его id из БД")
+    @Operation(summary = "Удаляет дефолтный вопрос по его id из БД")
     public void delete(@RequestBody int id) {
         defaultQuestionService.delete(id);
     }

--- a/platform_orchestrator/src/main/java/com/override/controller/rest/InterviewDataRestController.java
+++ b/platform_orchestrator/src/main/java/com/override/controller/rest/InterviewDataRestController.java
@@ -3,10 +3,9 @@ package com.override.controller.rest;
 import com.override.model.InterviewData;
 import com.override.service.InterviewDataService;
 import dto.InterviewDataDTO;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,34 +21,30 @@ public class InterviewDataRestController {
     private InterviewDataService interviewDataService;
 
     @GetMapping
-    @ApiOperation(value = "Возвращает список собеседований из БД")
+    @Operation(summary = "Возвращает список собеседований из БД")
     public List<InterviewDataDTO> findAllInterviewReports() {
         return interviewDataService.findAll();
     }
 
     @DeleteMapping
-    @ApiOperation(value = "Удаляет данные собеседования по его id из БД")
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Данные собеседования удалены")
-    })
-    public ResponseEntity<String> deleteInterview(@ApiParam(value = "id собеседования") @RequestParam Long id) {
+    @Operation(summary = "Удаляет данные собеседования по его id из БД")
+    @ApiResponse(responseCode = "200", description = "Данные собеседования удалены")
+    public ResponseEntity<String> deleteInterview(@Parameter(description = "id собеседования") @RequestParam Long id) {
         interviewDataService.delete(id);
         return new ResponseEntity<>("Данные собеседования удалены", HttpStatus.OK);
     }
 
     @PatchMapping("/save")
-    @ApiOperation(value = "Сохраняет данные собеседования в БД")
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Данные собеседования сохранены")
-    })
+    @Operation(summary = "Сохраняет данные собеседования в БД")
+    @ApiResponse(responseCode = "200", description = "Данные собеседования сохранены")
     public ResponseEntity<String> save(@RequestBody InterviewDataDTO interviewDataDTO) {
         interviewDataService.save(interviewDataDTO);
         return new ResponseEntity<>("Данные собеседования сохранены", HttpStatus.OK);
     }
 
     @GetMapping("/getData")
-    @ApiOperation(value = "Получает из БД данные собеседования по его id")
-    public ResponseEntity<InterviewData> getInterviewData(@ApiParam(value = "id собеседования") @RequestParam Long id) {
+    @Operation(summary = "Получает из БД данные собеседования по его id")
+    public ResponseEntity<InterviewData> getInterviewData(@Parameter(description = "id собеседования") @RequestParam Long id) {
         InterviewData interviewTable = interviewDataService.findById(id);
         return new ResponseEntity<>(interviewTable, HttpStatus.OK);
     }

--- a/platform_orchestrator/src/main/java/com/override/controller/rest/InterviewReportRestController.java
+++ b/platform_orchestrator/src/main/java/com/override/controller/rest/InterviewReportRestController.java
@@ -4,9 +4,8 @@ import com.override.model.enums.Status;
 import com.override.service.InterviewReportService;
 import dto.InterviewReportDTO;
 import dto.InterviewReportUpdateDTO;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,46 +21,38 @@ public class InterviewReportRestController {
     private InterviewReportService interviewReportService;
 
     @PatchMapping
-    @ApiOperation(value = "Сохраняет интервью репорт в БД")
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Отчёт о собеседовании сохранён!")
-    })
+    @Operation(summary = "Сохраняет интервью репорт в БД")
+    @ApiResponse(responseCode = "200", description = "Отчёт о собеседовании сохранён!")
     public ResponseEntity<String> saveInterviewReport(@RequestBody InterviewReportDTO interviewReportDTO) {
         interviewReportService.save(interviewReportDTO);
         return new ResponseEntity<>("Отчёт о собеседовании сохранён!", HttpStatus.OK);
     }
 
     @PatchMapping("/offer")
-    @ApiOperation(value = "Меняет статут в интервью репорте на \"Status.OFFER\"")
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Статус собеседования изменён на Offer!")
-    })
+    @Operation(summary = "Меняет статут в интервью репорте на \"Status.OFFER\"")
+    @ApiResponse(responseCode = "200", description = "Статус собеседования изменён на Offer!")
     public ResponseEntity<String> changeStatusToOffer(@RequestBody InterviewReportUpdateDTO interviewReportUpdateDTO) {
         interviewReportService.update(interviewReportUpdateDTO, Status.OFFER);
         return new ResponseEntity<>("Статус собеседования изменён на Offer!", HttpStatus.OK);
     }
 
     @PatchMapping("/accepted")
-    @ApiOperation(value = "Меняет статут в интервью репорте на \"Status.ACCEPTED\"")
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Статус собеседования изменён на Accepted!")
-    })
+    @Operation(summary = "Меняет статут в интервью репорте на \"Status.ACCEPTED\"")
+    @ApiResponse(responseCode = "200", description = "Статус собеседования изменён на Accepted!")
     public ResponseEntity<String> changeStatusToAccepted(@RequestBody InterviewReportUpdateDTO interviewReportUpdateDTO) {
         interviewReportService.update(interviewReportUpdateDTO, Status.ACCEPTED);
         return new ResponseEntity<>("Статус собеседования изменён на Accepted!", HttpStatus.OK);
     }
 
     @GetMapping
-    @ApiOperation(value = "Возвращает все интервью репорты из БД")
+    @Operation(summary = "Возвращает все интервью репорты из БД")
     public List<InterviewReportDTO> findAllInterviewReports() {
         return interviewReportService.findAll();
     }
 
     @DeleteMapping
-    @ApiOperation(value = "Удаляет интервью репорт по его id из БД")
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Отчёт о собеседовании удалён!")
-    })
+    @Operation(summary = "Удаляет интервью репорт по его id из БД")
+    @ApiResponse(responseCode = "200", description = "Отчёт о собеседовании удалён!")
     public ResponseEntity<String> deleteInterviewReport(@RequestParam Long id) {
         interviewReportService.delete(id);
         return new ResponseEntity<>("Отчёт о собеседовании удалён!", HttpStatus.OK);

--- a/platform_orchestrator/src/main/java/com/override/controller/rest/JoinRequestRestController.java
+++ b/platform_orchestrator/src/main/java/com/override/controller/rest/JoinRequestRestController.java
@@ -4,7 +4,7 @@ import com.override.model.JoinRequest;
 import com.override.service.JoinRequestService;
 import dto.JoinRequestStatusDTO;
 import dto.RegisterUserRequestDTO;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
@@ -18,20 +18,20 @@ public class JoinRequestRestController {
     private JoinRequestService requestService;
 
     @PostMapping("/join/request")
-    @ApiOperation(value = "Сохраняет запрос на регистрацию в БД, если пользователь еще не " +
+    @Operation(summary = "Сохраняет запрос на регистрацию в БД, если пользователь еще не " +
             "зарегистрирован, или не отправлял запрос ранее")
     public JoinRequestStatusDTO saveJoinRequest(@RequestBody RegisterUserRequestDTO requestDTO) {
         return requestService.saveRequest(requestDTO);
     }
 
     @GetMapping("/join/request")
-    @ApiOperation(value = "Возвращает весь список запросов на регистрацию из БД")
+    @Operation(summary = "Возвращает весь список запросов на регистрацию из БД")
     public List<JoinRequest> getAllJoinRequests() {
         return requestService.getAllRequests();
     }
 
     @PostMapping("/join/request/accept/{id}")
-    @ApiOperation(value = "Админ принимает запрос на регистрацию. В телеграм пользователю отправляется " +
+    @Operation(summary = "Админ принимает запрос на регистрацию. В телеграм пользователю отправляется " +
             "сообщение о принятии запроса, а так же логин и пароль для входа на платформу. Запрос удаляется из БД")
     public void acceptJoinRequest(@PathVariable Long id) {
         requestService.responseForJoinRequest(true, id);
@@ -39,7 +39,7 @@ public class JoinRequestRestController {
 
     @Secured("ROLE_ADMIN")
     @PostMapping("/join/request/decline/{id}")
-    @ApiOperation(value = "Админ не принимает запрос на регистрацию. В телеграм пользователю отправляется " +
+    @Operation(summary = "Админ не принимает запрос на регистрацию. В телеграм пользователю отправляется " +
             "сообщение об отклонении запроса. Запрос удаляется из БД")
     public void declineJoinRequest(@PathVariable Long id) {
         requestService.responseForJoinRequest(false, id);

--- a/platform_orchestrator/src/main/java/com/override/controller/rest/LessonProgressRestController.java
+++ b/platform_orchestrator/src/main/java/com/override/controller/rest/LessonProgressRestController.java
@@ -3,7 +3,7 @@ package com.override.controller.rest;
 import com.override.service.CustomStudentDetailService;
 import com.override.service.LessonProgressService;
 import com.override.service.PlatformUserService;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -22,7 +22,7 @@ public class LessonProgressRestController {
     private PlatformUserService platformUserService;
 
     @PostMapping("/{lesson}")
-    @ApiOperation(value = "Создается объект \"прогресс урока\" (по имени текущего юзера и уроку) и сохраняется в БД, " +
+    @Operation(summary = "Создается объект \"прогресс урока\" (по имени текущего юзера и уроку) и сохраняется в БД, " +
             "если его там еще нет. Другими словами указанный урок вносится в коллекцию с пройдеными уроками, " +
             "тем самым \"помечает\" его как пройденный")
     public void checkLesson(@AuthenticationPrincipal CustomStudentDetailService.CustomStudentDetails user,
@@ -32,13 +32,13 @@ public class LessonProgressRestController {
 
     @Secured("ROLE_ADMIN")
     @GetMapping("/allStat/{login}")
-    @ApiOperation(value = "Возвращает список пройденных юзером уроков, по логину юзера для админа.")
+    @Operation(summary = "Возвращает список пройденных юзером уроков, по логину юзера для админа.")
     public List<String> getPassedLessons(@PathVariable String login) {
         return lessonProgressService.getPassedLessons(platformUserService.findPlatformUserByLogin(login));
     }
 
     @GetMapping("/allStat")
-    @ApiOperation(value = "Возвращает список пройденных юзером уроков, для текущего юзера.")
+    @Operation(summary = "Возвращает список пройденных юзером уроков, для текущего юзера.")
     public List<String> getPassedLessonsForCurrentUser(
             @AuthenticationPrincipal CustomStudentDetailService.CustomStudentDetails user) {
         return lessonProgressService.getPassedLessons(platformUserService.findPlatformUserByLogin(user.getUsername()));

--- a/platform_orchestrator/src/main/java/com/override/controller/rest/NavbarRestController.java
+++ b/platform_orchestrator/src/main/java/com/override/controller/rest/NavbarRestController.java
@@ -2,7 +2,7 @@ package com.override.controller.rest;
 
 import com.override.model.domain.NavbarElement;
 import com.override.service.NavbarService;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,7 +17,7 @@ public class NavbarRestController {
     private NavbarService navbarService;
 
     @GetMapping("/navbar")
-    @ApiOperation(value = "Возвращает список \"навбар элементов\". Либо для админа, либо для юзера, либо для выпусника, " +
+    @Operation(summary = "Возвращает список \"навбар элементов\". Либо для админа, либо для юзера, либо для выпусника, " +
             "смотря кто заходит на платформу.")
     public List<NavbarElement> getNavbar(HttpServletRequest request) {
         return navbarService.getNavbar(request);

--- a/platform_orchestrator/src/main/java/com/override/controller/rest/NotificationRestController.java
+++ b/platform_orchestrator/src/main/java/com/override/controller/rest/NotificationRestController.java
@@ -3,7 +3,7 @@ package com.override.controller.rest;
 import com.override.feign.NotificatorFeign;
 import com.override.service.VerificationService;
 import dto.BalanceResponseFromNotificationControllerDTO;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,41 +26,41 @@ public class NotificationRestController {
 
     @Secured("ROLE_ADMIN")
     @GetMapping("/balance")
-    @ApiOperation(value = "Возвращает значение баланса для админа и ссылку на пополнение https://sms.ru/pay.php")
+    @Operation(summary = "Возвращает значение баланса для админа и ссылку на пополнение https://sms.ru/pay.php")
     public BalanceResponseFromNotificationControllerDTO getBalanceDTO() {
         return new BalanceResponseFromNotificationControllerDTO(notificatorFeign.getBalance(), urlToReplenishBalance);
     }
 
     @PatchMapping("/phone")
-    @ApiOperation(value = "Пользователю на телефон поступает звонок для подтверждения номера телефона",
-            notes = "Последние четыре цифры номера телефона, с которого происходит звонок - код для подтверждения. " +
-                    "Данный код сохраняется в кэш для дальнейшего сравнения с кодом, который введет пользоваетль")
+    @Operation(summary = "Пользователю на телефон поступает звонок для подтверждения номера телефона",
+            description = "Последние четыре цифры номера телефона, с которого происходит звонок - код для подтверждения. " +
+            "Данный код сохраняется в кэш для дальнейшего сравнения с кодом, который введет пользоваетль")
     public void getCodeCallSecurity(@RequestParam String phone) {
         verificationService.getCodeCallSecurity(phone);
     }
 
     @PatchMapping("/email")
-    @ApiOperation(value = "Пользователю на электронную почту приходит сообщение с кодом подтверждения.",
-            notes = "Данный код сохраняется в кэш для дальнейшего сравнения с кодом, который введет пользоваетль")
+    @Operation(summary = "Пользователю на электронную почту приходит сообщение с кодом подтверждения.",
+            description = "Данный код сохраняется в кэш для дальнейшего сравнения с кодом, который введет пользоваетль")
     public void getCodeEmailSecurity(@RequestParam String email) {
         verificationService.getCodeEmailSecurity(email);
     }
 
     @PatchMapping("/codePhone/{codePhone}/{phoneNumber}")
-    @ApiOperation(value = "Возвращает 'true', если введеный пользователем код для подтверждения номера телефона верный, либо 'false', если код не верный")
+    @Operation(summary = "Возвращает 'true', если введеный пользователем код для подтверждения номера телефона верный, либо 'false', если код не верный")
     public boolean getCodePhone(@PathVariable String codePhone, @PathVariable String phoneNumber) {
         return verificationService.getCodePhone(codePhone, phoneNumber);
     }
 
     @PatchMapping("/codeEmail/{codeEmail}/{email}")
-    @ApiOperation(value = "Возвращает 'true', если введеный пользователем код для подтверждения электроннной почты верный, либо 'false', если код не верный")
+    @Operation(summary = "Возвращает 'true', если введеный пользователем код для подтверждения электроннной почты верный, либо 'false', если код не верный")
     public boolean getCodeEmail(@PathVariable String codeEmail, @PathVariable String email) {
         return verificationService.getCodeEmail(codeEmail, email);
     }
 
     @PatchMapping("/contacts/{login}/{email}/{phoneNumber}")
-    @ApiOperation(value = "Сохраняет подтвержденные номер телефона и адрес электронной почты в БД",
-            notes = "Сохраняет номер телефона и адрес электронной почты в таблицу с персональными данными в оркестратор и в таблицу получателей в нотификатор")
+    @Operation(summary = "Сохраняет подтвержденные номер телефона и адрес электронной почты в БД",
+            description = "Сохраняет номер телефона и адрес электронной почты в таблицу с персональными данными в оркестратор и в таблицу получателей в нотификатор")
     public void savePhoneNumberAndEmail(@PathVariable String login, @PathVariable String email, @PathVariable Long phoneNumber) {
         verificationService.savePhoneNumberAndEmail(login, email, phoneNumber);
     }

--- a/platform_orchestrator/src/main/java/com/override/controller/rest/PaymentRestController.java
+++ b/platform_orchestrator/src/main/java/com/override/controller/rest/PaymentRestController.java
@@ -4,9 +4,8 @@ import com.override.model.Payment;
 import com.override.service.CustomStudentDetailService;
 import com.override.service.PaymentService;
 import dto.PaymentDTO;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,10 +22,8 @@ public class PaymentRestController {
     private PaymentService paymentService;
 
     @PostMapping
-    @ApiOperation(value = "Сохраняет или обновляет данные платежа в БД")
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Счет на оплату добавлен!")
-    })
+    @Operation(summary = "Сохраняет или обновляет данные платежа в БД")
+    @ApiResponse(responseCode = "200", description = "Счет на оплату добавлен!")
     public ResponseEntity<String> saveOrUpdatePayment(@RequestBody PaymentDTO paymentDTO,
                                                       @AuthenticationPrincipal CustomStudentDetailService.CustomStudentDetails user) {
         paymentService.save(paymentDTO, user.getUsername());
@@ -34,7 +31,7 @@ public class PaymentRestController {
     }
 
     @GetMapping
-    @ApiOperation(value = "Возвращает список всех платежей")
+    @Operation(summary = "Возвращает список всех платежей")
     private List<Payment> getAllPayments() {
         return paymentService.getAll();
     }

--- a/platform_orchestrator/src/main/java/com/override/controller/rest/PersonalDataRestController.java
+++ b/platform_orchestrator/src/main/java/com/override/controller/rest/PersonalDataRestController.java
@@ -3,8 +3,8 @@ package com.override.controller.rest;
 import com.override.model.RequestPersonalData;
 import com.override.service.PersonalDataService;
 import dto.PersonalDataDTO;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
@@ -17,33 +17,30 @@ public class PersonalDataRestController {
     private PersonalDataService personalDataService;
 
     @PatchMapping("{userLogin}")
-    @ApiOperation(
-            value = "Сохранение данных в БД",
-            notes = "Сохранение персональных данных в таблицу с персональными данными, " +
+    @Operation(summary = "Сохранение данных в БД",
+            description = "Сохранение персональных данных в таблицу с персональными данными, " +
                     "либо в таблицу запросов на изменение персональных данных в зависимости от контекста," +
                     "а также сохранение данных в таблицу получателей в Нотификатор")
     public void patch(@RequestBody PersonalDataDTO personalDataDTO,
-                      @ApiParam(value = "Логин пользователя", example = "Shu") @PathVariable String userLogin) {
+                      @Parameter(description = "Логин пользователя", example = "Shu") @PathVariable String userLogin) {
         personalDataService.saveOrCreateRequest(personalDataDTO, userLogin);
     }
 
     @GetMapping("/requestToCheck/{userLogin}")
-    @ApiOperation(
-            value = "Поиск запроса на изменение",
-            notes = "Поиск запроса на изменение в таблице запросов на изменение персональных данных")
+    @Operation(summary = "Поиск запроса на изменение",
+            description = "Поиск запроса на изменение в таблице запросов на изменение персональных данных")
     public RequestPersonalData request(
-            @ApiParam(value = "Логин пользователя", example = "Shu") @PathVariable String userLogin) {
+            @Parameter(description = "Логин пользователя", example = "Shu") @PathVariable String userLogin) {
         return personalDataService.findRequestPersonalDataByLogin(userLogin);
     }
 
     @Secured("ROLE_ADMIN")
     @PatchMapping("/requestToCheck/{userLogin}")
-    @ApiOperation(
-            value = "Согласование запроса на изменние персональных данных",
-            notes = "Сохранение данных в таблице с персональными данными " +
+    @Operation(summary = "Согласование запроса на изменние персональных данных",
+            description = "Сохранение данных в таблице с персональными данными " +
                     "и удаление данных из таблицы запросов на изменение персональных данных")
     public void saveUsersPersonalData(@RequestBody PersonalDataDTO personalDataDTO,
-                                      @ApiParam(value = "Логин пользователя", example = "Shu")
+                                      @Parameter(description = "Логин пользователя", example = "Shu")
                                       @PathVariable String userLogin) {
         personalDataService.save(personalDataDTO, userLogin);
         personalDataService.deleteRequestToCheck(personalDataDTO);

--- a/platform_orchestrator/src/main/java/com/override/controller/rest/PlatformUserRestController.java
+++ b/platform_orchestrator/src/main/java/com/override/controller/rest/PlatformUserRestController.java
@@ -6,7 +6,7 @@ import com.override.model.enums.Role;
 import com.override.service.CustomStudentDetailService;
 import com.override.service.PlatformUserService;
 import enums.StudyStatus;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
@@ -24,45 +24,45 @@ public class PlatformUserRestController {
     private PlatformUserService platformUserService;
 
     @GetMapping("/role")
-    @ApiOperation(value = "Возвращает роль пользователя")
+    @Operation(summary = "Возвращает роль пользователя")
     public Role getPlatformUserRole(HttpServletRequest request) {
         return platformUserService.getPlatformUserRole(request);
     }
 
     @GetMapping("/current")
-    @ApiOperation(value = "Возвращает \"платформ юзера\" из БД для текущего пользователя")
+    @Operation(summary = "Возвращает \"платформ юзера\" из БД для текущего пользователя")
     public PlatformUser findPlatformUser(@AuthenticationPrincipal CustomStudentDetailService.CustomStudentDetails user) {
         return platformUserService.findPlatformUserByLogin(user.getUsername());
     }
 
     @GetMapping("/{login}")
-    @ApiOperation(value = "Возвращает \"платформ юзера\" из БД по логину")
+    @Operation(summary = "Возвращает \"платформ юзера\" из БД по логину")
     public PlatformUser findPlatformUserByLogin(@PathVariable String login) {
         return platformUserService.findPlatformUserByLogin(login);
     }
 
     @GetMapping("/coursePart")
-    @ApiOperation(value = "Возвращает \"часть курса\" из БД текущего пользователя")
+    @Operation(summary = "Возвращает \"часть курса\" из БД текущего пользователя")
     public CoursePart getCoursePart(@AuthenticationPrincipal CustomStudentDetailService.CustomStudentDetails user) {
         return platformUserService.getCurrentCoursePart(user.getUsername());
     }
 
     @Secured("ROLE_ADMIN")
     @GetMapping
-    @ApiOperation(value = "Возвращает список всех \"платформ юзеров\", кроме админов)")
+    @Operation(summary = "Возвращает список всех \"платформ юзеров\", кроме админов)")
     public List<PlatformUser> getAllStudents() {
         return platformUserService.getAllStudents();
     }
 
     @Secured("ROLE_ADMIN")
     @PostMapping("/{id}/{role}")
-    @ApiOperation(value = "Обновляет роль \"платформ юзера\" и сохраняет в БД")
+    @Operation(summary = "Обновляет роль \"платформ юзера\" и сохраняет в БД")
     public ResponseEntity<String> updateUserRole(@PathVariable Long id, @PathVariable Role role) {
         return platformUserService.updateUserRole(id, role);
     }
 
     @Secured("ROLE_ADMIN")
-    @ApiOperation(value = "Обновляет \"часть курса\" \"платформ юзера\" и сохраняет в БД")
+    @Operation(summary = "Обновляет \"часть курса\" \"платформ юзера\" и сохраняет в БД")
     @PostMapping("/promoteCoursePart/{id}/{coursePart}")
     public ResponseEntity<String> updateCoursePart(@PathVariable Long id, @PathVariable CoursePart coursePart) {
         return platformUserService.updateCurrentCoursePart(id, coursePart);
@@ -70,7 +70,7 @@ public class PlatformUserRestController {
 
     @Secured("ROLE_ADMIN")
     @PutMapping("/{id}/{status}")
-    @ApiOperation(value = "Обновляет \"статус обучения\" \"платформ юзера\" и сохраняет в БД")
+    @Operation(summary = "Обновляет \"статус обучения\" \"платформ юзера\" и сохраняет в БД")
     public ResponseEntity<String> updateWorkStatus(@PathVariable Long id, @PathVariable String status) {
         return platformUserService.updateStatus(id, StudyStatus.valueOf(status));
     }

--- a/platform_orchestrator/src/main/java/com/override/controller/rest/PreProjectLessonsController.java
+++ b/platform_orchestrator/src/main/java/com/override/controller/rest/PreProjectLessonsController.java
@@ -4,9 +4,8 @@ import com.override.service.CustomStudentDetailService;
 import com.override.service.PreProjectLessonService;
 import dto.PreProjectLessonDTO;
 import dto.PreProjectLessonMentorReactionDTO;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,29 +24,27 @@ public class PreProjectLessonsController {
 
     @Secured("ROLE_ADMIN")
     @GetMapping
-    @ApiOperation(value = "Возвращает весь список \"предпроектных уроков\" из БД")
+    @Operation(summary = "Возвращает весь список \"предпроектных уроков\" из БД")
     public List<PreProjectLessonMentorReactionDTO> getAll() {
         return preProjectLessonService.getAll();
     }
 
     @PostMapping("/current")
-    @ApiOperation(value = "Возвращает список \"предпроектных уроков\" для текущего юзера по идентификатору задачи, который берется из ДТОшки")
+    @Operation(summary = "Возвращает список \"предпроектных уроков\" для текущего юзера по идентификатору задачи, который берется из ДТОшки")
     public List<PreProjectLessonMentorReactionDTO> getCurrent(@RequestBody PreProjectLessonDTO preProjectLessonDTO, @AuthenticationPrincipal CustomStudentDetailService.CustomStudentDetails user) {
         return preProjectLessonService.getAllByPathName(preProjectLessonDTO, user.getUsername());
     }
 
     @PostMapping
-    @ApiOperation(value = "Сохраняет \"предпроектный урок\" в БД, ссылку и идентификатор задачи берется из ДТОшки")
+    @Operation(summary = "Сохраняет \"предпроектный урок\" в БД, ссылку и идентификатор задачи берется из ДТОшки")
     public PreProjectLessonDTO savePreProjectLessonLink(@RequestBody PreProjectLessonDTO preProjectLessonDTO, @AuthenticationPrincipal CustomStudentDetailService.CustomStudentDetails user) {
         return preProjectLessonService.save(preProjectLessonDTO, user.getUsername());
     }
 
     @PatchMapping
-    @ApiOperation(value = "Сохраняет \"предпроектный урок\" в БД, при этом обновляя поля Comments, Approve, " +
+    @Operation(summary = "Сохраняет \"предпроектный урок\" в БД, при этом обновляя поля Comments, Approve, " +
             "Viewed у \"предпроектного урока\", который мы получаем из ДТОшки.")
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Комментарии сохранены!")
-    })
+    @ApiResponse(responseCode = "200", description = "Комментарии сохранены!")
     public ResponseEntity<String> updatePreProjectLessonLink(@RequestBody PreProjectLessonMentorReactionDTO preProjectLessonMentorReactionDTO) {
         preProjectLessonService.update(preProjectLessonMentorReactionDTO);
         return new ResponseEntity<>("Комментарии сохранены!", HttpStatus.OK);

--- a/platform_orchestrator/src/main/java/com/override/controller/rest/QuestionRestController.java
+++ b/platform_orchestrator/src/main/java/com/override/controller/rest/QuestionRestController.java
@@ -5,7 +5,7 @@ import com.override.service.CustomStudentDetailService;
 import com.override.service.LessonStructureService;
 import com.override.service.QuestionService;
 import dto.QuestionDTO;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -24,42 +24,42 @@ public class QuestionRestController {
 
     @Secured("ROLE_ADMIN")
     @GetMapping("/{login}/{chapter}")
-    @ApiOperation(value = "Возвращает список вопросов по логину и главе")
+    @Operation(summary = "Возвращает список вопросов по логину и главе")
     public List<Question> findAll(@PathVariable String login,
                                   @PathVariable String chapter) {
         return questionService.findAllByUserAndChapter(login, chapter);
     }
 
     @GetMapping("/my/{chapter}")
-    @ApiOperation(value = "Возвращает список вопросов по логину и главе для текущего пользователся")
+    @Operation(summary = "Возвращает список вопросов по логину и главе для текущего пользователся")
     public List<Question> findAllPersonal(@AuthenticationPrincipal CustomStudentDetailService.CustomStudentDetails user,
                                           @PathVariable String chapter) {
         return questionService.findAllByUserAndChapter(user.getUsername(), chapter);
     }
 
     @GetMapping("/chapters")
-    @ApiOperation(value = "Возвращает список глав, по которым есть вопросы")
+    @Operation(summary = "Возвращает список глав, по которым есть вопросы")
     public List<String> findAllChapters() {
         return lessonStructureService.getChapterNamesList();
     }
 
     @Secured("ROLE_ADMIN")
     @PostMapping
-    @ApiOperation(value = "Сохраняет вопрос в БД, данные берет из ДТОшки")
+    @Operation(summary = "Сохраняет вопрос в БД, данные берет из ДТОшки")
     public void save(@RequestBody QuestionDTO questionDTO) {
         questionService.save(questionDTO);
     }
 
     @Secured("ROLE_ADMIN")
     @PatchMapping
-    @ApiOperation(value = "Обновляет вопрос в БД, данные берет из ДТОшки")
+    @Operation(summary = "Обновляет вопрос в БД, данные берет из ДТОшки")
     public void patch(@RequestBody QuestionDTO questionDTO) {
         questionService.patch(questionDTO);
     }
 
     @Secured("ROLE_ADMIN")
     @DeleteMapping
-    @ApiOperation(value = "Удаляет вопрос из БД по id")
+    @Operation(summary = "Удаляет вопрос из БД по id")
     public void delete(@RequestParam long id) {
         questionService.delete(id);
     }

--- a/platform_orchestrator/src/main/java/com/override/controller/rest/ReportRestController.java
+++ b/platform_orchestrator/src/main/java/com/override/controller/rest/ReportRestController.java
@@ -2,7 +2,7 @@ package com.override.controller.rest;
 
 import com.override.model.StudentReport;
 import com.override.service.ReportService;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -21,7 +21,7 @@ public class ReportRestController {
     private ReportService reportService;
 
     @PostMapping
-    @ApiOperation(value = "Сохраняет отчет текущего пользователя в БД, если на эту дату еще нет отчета")
+    @Operation(summary = "Сохраняет отчет текущего пользователя в БД, если на эту дату еще нет отчета")
     public ResponseEntity<String> postReport(@RequestBody StudentReport report, @AuthenticationPrincipal CustomStudentDetails user) {
         return reportService.saveReport(report, user.getUsername());
     }

--- a/platform_orchestrator/src/main/java/com/override/controller/rest/ReviewRestController.java
+++ b/platform_orchestrator/src/main/java/com/override/controller/rest/ReviewRestController.java
@@ -6,10 +6,9 @@ import com.override.service.VkApiService;
 import dto.ReviewDTO;
 import dto.ReviewFilterDTO;
 import dto.VkActorDTO;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -30,7 +29,8 @@ public class ReviewRestController {
     private VkApiService vkApiService;
 
     @PatchMapping
-    @ApiOperation(notes = "Варианты условий:\n" +
+    @Operation(summary = "Сохраняет новое или изменяет существующее ревью.",
+            description = "Варианты условий:\n" +
             "reviewDTO.getId() == null, reviewDTO.getStudentLogin() == null — будет отправлено уведомление в Telegram\n" +
             "ментору о новом запросе на ревью от студента. Имя пользователя студента отправляется в reviewDTO.\n" +
             "Когда ревью только создается, подразумевается, что этот запрос делает студент,\n" +
@@ -42,33 +42,28 @@ public class ReviewRestController {
             "reviewDTO.getMentorLogin() != null && reviewDTO.getBookedTime() != null - изменения вносятся в уже\n" +
             "подтвержденное ревью. А дальше уже два варианта:\n" +
             "!reviewDTO.getMentorLogin().equals(userLogin) - будет отправлено уведомление о смене ментора с указанием времени.\n" +
-            "reviewDTO.getMentorLogin().equals(userLogin) - если логины совпадают, отправляется уведомление об изменении времени",
-            value = "Сохраняет новое или изменяет существующее ревью.")
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Ревью сохранено!")
-    })
-    public ResponseEntity<String> saveOrUpdateReview(@RequestBody @ApiParam(value = "reviewDTO проверяет информацию, полученную из запроса") ReviewDTO reviewDTO,
+            "reviewDTO.getMentorLogin().equals(userLogin) - если логины совпадают, отправляется уведомление об изменении времени")
+    @ApiResponse(responseCode = "200", description = "Ревью сохранено!")
+    public ResponseEntity<String> saveOrUpdateReview(@RequestBody @Parameter(description = "reviewDTO проверяет информацию, полученную из запроса") ReviewDTO reviewDTO,
                                                      @AuthenticationPrincipal CustomStudentDetailService.CustomStudentDetails user) {
         reviewService.saveOrUpdate(reviewDTO, user.getUsername());
         return new ResponseEntity<>("Ревью сохранено!", HttpStatus.OK);
     }
 
     @PostMapping
-    @ApiOperation(notes = "Поиск выбранных ревью с использованием фильтра.\n" +
+    @Operation(summary = "Возвращает список ревью, полученный путем сопоставления списка найденных отзывов.",
+            description = "Поиск выбранных ревью с использованием фильтра.\n" +
             "Ревью можно найти по логину студента или ментора, а также по дате.\n" +
-            "Если эти параметры имеют значение null, то отбираются новые ревью, которым еще не назначены ментор и время",
-            value = "Возвращает список ревью, полученный путем сопоставления списка найденных отзывов.")
-    public List<ReviewDTO> findReview(@RequestBody @ApiParam(value = "reviewFilterDTO поступает из запроса")
+            "Если эти параметры имеют значение null, то отбираются новые ревью, которым еще не назначены ментор и время")
+    public List<ReviewDTO> findReview(@RequestBody @Parameter(description = "reviewFilterDTO поступает из запроса")
                                           ReviewFilterDTO reviewFilterDTO) {
         return reviewService.find(reviewFilterDTO);
     }
 
     @Secured("ROLE_ADMIN")
     @DeleteMapping
-    @ApiOperation(value = "Удаляет ревью по id")
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Ревью удалено!")
-    })
+    @Operation(summary = "Удаляет ревью по id")
+    @ApiResponse(responseCode = "200", description = "Ревью удалено!")
     public ResponseEntity<String> deleteReview(@RequestParam Long id) {
         reviewService.delete(id);
         return new ResponseEntity<>("Ревью удалено!", HttpStatus.OK);
@@ -76,15 +71,15 @@ public class ReviewRestController {
 
     @Secured("ROLE_ADMIN")
     @PatchMapping("/createVkCall")
-    @ApiOperation(value = "Создание звонка в ВК", notes = "Делает запрос по open VK API на создание звонка")
-    public void createVkCallCall(@ApiParam(value = "ID ревью", example = "Shu") @RequestParam Long reviewId,
+    @Operation(summary = "Создание звонка в ВК", description = "Делает запрос по open VK API на создание звонка")
+    public void createVkCallCall(@Parameter(description = "ID ревью", example = "Shu") @RequestParam Long reviewId,
                                  @RequestBody VkActorDTO vkActorDTO) {
         vkApiService.createVkCall(reviewId, vkActorDTO);
     }
 
     @Secured("ROLE_ADMIN")
     @GetMapping("/vkAppId")
-    @ApiOperation(value = "Запрос на ID VK приложения")
+    @Operation(summary = "Запрос на ID VK приложения")
     public Long getVkAppId() {
         System.out.println(vkApiService.getVkAppId());
         return vkApiService.getVkAppId();

--- a/platform_orchestrator/src/main/java/com/override/controller/rest/StatisticsRestController.java
+++ b/platform_orchestrator/src/main/java/com/override/controller/rest/StatisticsRestController.java
@@ -5,7 +5,7 @@ import dto.CodeTryStatDTO;
 import dto.GeneralIncomeDTO;
 import dto.IncomeFromUsersDTO;
 import dto.SalaryDTO;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +22,7 @@ public class StatisticsRestController {
     private StatisticsService statisticsService;
 
     @GetMapping("/hardTasks")
-    @ApiOperation(value = "Возвращает мапу Map<String, Long>, где ключ(String) - номер той самой сложной " +
+    @Operation(summary = "Возвращает мапу Map<String, Long>, где ключ(String) - номер той самой сложной " +
             "задачи (пример: 4.2.1, где 4 - глава, 2 - шаг, 1 - урок), а значение(Long) - колчичество неудачных " +
             "решений данной задачи")
     public Map<String, Long> statList(@RequestParam int size){
@@ -30,25 +30,25 @@ public class StatisticsRestController {
     }
 
     @GetMapping("/data")
-    @ApiOperation(value = "Возвращает CodeTryStatDTO, подробно описно в модели ДТОшки")
+    @Operation(summary = "Возвращает CodeTryStatDTO, подробно описно в модели ДТОшки")
     public CodeTryStatDTO countStatsByStatus(@RequestParam int size){
         return statisticsService.getCodeTryStatistics(size);
     }
 
     @GetMapping("/salary")
-    @ApiOperation(value = "Возвращает SalaryDTO, подробно описно в модели ДТОшки")
+    @Operation(summary = "Возвращает SalaryDTO, подробно описно в модели ДТОшки")
     public SalaryDTO getSalaryStat(){
         return statisticsService.getSalaryStatistics();
     }
 
     @GetMapping("/allPayment")
-    @ApiOperation(value = "Возвращает IncomeFromUsersDTO, подробно описно в модели ДТОшки")
+    @Operation(summary = "Возвращает IncomeFromUsersDTO, подробно описно в модели ДТОшки")
     public IncomeFromUsersDTO getAllPayment(){
         return statisticsService.getAllPayment();
     }
 
     @GetMapping("/generalIncome")
-    @ApiOperation(value = "Возвращает GeneralIncomeDTO, подробно описно в модели ДТОшки")
+    @Operation(summary = "Возвращает GeneralIncomeDTO, подробно описно в модели ДТОшки")
     public GeneralIncomeDTO getGeneralPayment(){
         return statisticsService.getGeneralPayment();
     }

--- a/platform_orchestrator/src/main/java/com/override/controller/rest/UserSettingsRestController.java
+++ b/platform_orchestrator/src/main/java/com/override/controller/rest/UserSettingsRestController.java
@@ -2,7 +2,7 @@ package com.override.controller.rest;
 
 import com.override.model.UserSettings;
 import com.override.service.UserSettingsService;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,7 +14,7 @@ public class UserSettingsRestController {
     private UserSettingsService userSettingsService;
 
     @PatchMapping("/{userLogin}")
-    @ApiOperation(value = "Сохраняет \"пользовательские настройки\" в БД, по сути разрешает или запрещает " +
+    @Operation(summary = "Сохраняет \"пользовательские настройки\" в БД, по сути разрешает или запрещает " +
             "отправлять уведомления пользователю в Телеграм и ВК)")
     public void patch(@RequestBody UserSettings userSettings,
                       @PathVariable String userLogin) {

--- a/platform_orchestrator/src/main/java/com/override/controller/rest/YooMoneyRestController.java
+++ b/platform_orchestrator/src/main/java/com/override/controller/rest/YooMoneyRestController.java
@@ -3,7 +3,7 @@ package com.override.controller.rest;
 import com.override.service.YooMoneyService;
 import dto.YooMoneyConfirmationResponseDTO;
 import dto.YooMoneyRequestInfoDTO;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,7 +14,7 @@ public class YooMoneyRestController {
     private YooMoneyService yooMoneyService;
 
     @PostMapping("/yooMoney/authorize")
-    @ApiOperation(value = "Запрашивает и возвращает confirmation token для оплаты через Юкассу")
+    @Operation(summary = "Запрашивает и возвращает confirmation token для оплаты через Юкассу")
     public YooMoneyConfirmationResponseDTO getConfirmationToken(@RequestBody YooMoneyRequestInfoDTO infoDTO) {
         return yooMoneyService.getConfirmationResponseDTO(infoDTO);
     }

--- a/platform_orchestrator/src/main/java/com/override/model/Bug.java
+++ b/platform_orchestrator/src/main/java/com/override/model/Bug.java
@@ -1,7 +1,7 @@
 package com.override.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -22,7 +22,7 @@ public class Bug {
 
     private String name;
 
-    @ApiModelProperty(value = "Значение берется из файла MultipartFile, который приходит с фроната, " +
+    @Schema(description = "Значение берется из файла MultipartFile, который приходит с фроната, " +
             "если файла нет, то подставляется дефолтное значение - \"text\"")
     private String text;
 

--- a/platform_orchestrator/src/main/java/com/override/model/LessonProgress.java
+++ b/platform_orchestrator/src/main/java/com/override/model/LessonProgress.java
@@ -1,7 +1,7 @@
 package com.override.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -21,7 +21,7 @@ public class LessonProgress {
     @JsonIgnore
     private Long id;
 
-    @ApiModelProperty(value = "Идентификатор урока", example = "core-1-1")
+    @Schema(description = "Идентификатор урока", example = "core-1-1")
     private String lesson;
 
     @JoinColumn(name = "user_id")

--- a/platform_orchestrator/src/main/resources/application.yml
+++ b/platform_orchestrator/src/main/resources/application.yml
@@ -49,6 +49,8 @@ spring:
         smtp:
           starttls:
             enable: true
+  main:
+    allow-circular-references: true
 
 documentSizeLimit:
   forPersonalData: 5 # 5 МБ

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.6</version>
+        <version>2.7.9</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -31,7 +31,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>11</java.version>
         <javafaker.version>1.0.2</javafaker.version>
-        <spring.cloud-version>2020.0.3</spring.cloud-version>
+        <spring.cloud-version>2021.0.3</spring.cloud-version>
         <java.version>1.8</java.version>
         <h2.version>1.4.199</h2.version>
         <postgres.version>42.2.10</postgres.version>
@@ -58,6 +58,13 @@
                 <artifactId>spring-boot-starter-test</artifactId>
                 <version>2.6.3</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.data</groupId>
+                <artifactId>spring-data-bom</artifactId>
+                <version>2021.2.9</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Версия Spring Boot повышена с 2.5.6 до 2.7.9, а Spring Cloud до 2021.0.3.

В application.yml свойство spring.main.allow-circular-references: true необходимо для обратной совместимости со старым способом внедрения зависимостей (в версии 2.5.6 spring boot проблем не возникало, это обновление еще с версии 2.6).

Также была добавлена зависимость spring-data-bom. Эта зависимость необходима для нормальной работы с @Query (баг spring boot 2.7.9).

Springfox-swagger не поддерживается spring boot начиная с версии 2.6.0, поэтому было принято решение заменить на springdoc-openapi. Все аннотации были изменены на новые.